### PR TITLE
Ignore default credential artifact

### DIFF
--- a/build_and_deploy/test/helpers/utils_test_helpers.ts
+++ b/build_and_deploy/test/helpers/utils_test_helpers.ts
@@ -317,6 +317,16 @@ export var armTemplate_complete = "{\n" +
     "        }\n" +
     "      },\n" +
     "      \"dependsOn\": []\n" +
+    "    },\n"+
+    "    {\n" +
+    "      \"name\": \"[concat(parameters('workspaceName'), '/WorkspaceSystemIdentity')]\",\n" +
+    "      \"type\": \"Microsoft.Synapse/workspaces/credentials\",\n" +
+    "      \"apiVersion\": \"2019-06-01-preview\",\n" +
+    "      \"properties\": {\n" +
+    "        \"type\": \"ManagedIdentity\",\n" +
+    "        \"typeProperties\": {}\n" +
+    "      },\n" +
+    "      \"dependsOn\": []\n" +
     "    }\n" +
     "  ]\n" +
     "}";

--- a/build_and_deploy/test/utils_test.ts
+++ b/build_and_deploy/test/utils_test.ts
@@ -43,11 +43,13 @@ describe("Test Arm template utils", () => {
 
     it('should populate the arm template', () => {
         let targetWorkspaceName = "MochaTesting";
-        let completeArmTemplate = createArmTemplate(armParams, armTemplate, "", targetWorkspaceName);
+        let completeArmTemplate = createArmTemplate(armParams, armTemplate_complete, "", targetWorkspaceName);
         expect(completeArmTemplate).to.be.equal(expectedArmTemplate);
 
         let defaultArtifacts = findDefaultArtifacts(completeArmTemplate, targetWorkspaceName);
         expect(defaultArtifacts.get('github-cicd-1-WorkspaceDefaultSqlServer')).to.be.equal('MochaTesting-WorkspaceDefaultSqlServer');
+        expect(defaultArtifacts.get('github-cicd-1-WorkspaceDefaultStorage')).to.be.equal('MochaTesting-WorkspaceDefaultStorage');
+        expect(defaultArtifacts.get('github-cicd-1-WorkspaceSystemIdentity')).to.be.equal('MochaTesting-WorkspaceSystemIdentity');
     });
 
     it('should populate arm resources and dependency tree', async () => {

--- a/build_and_deploy/utils/arm_template_utils.ts
+++ b/build_and_deploy/utils/arm_template_utils.ts
@@ -90,7 +90,8 @@ export function findDefaultArtifacts(armTemplate: string, targetworkspace: strin
         let artifactJson = jsonArmTemplateParams.resources[value];
         let artifactName: string = artifactJson.name;
         if (artifactName.toLowerCase().indexOf("workspacedefaultsqlserver") >= 0 ||
-            artifactName.toLowerCase().indexOf("workspacedefaultstorage") >= 0) {
+            artifactName.toLowerCase().indexOf("workspacedefaultstorage") >= 0 ||
+            artifactName.toLowerCase().indexOf("workspacesystemidentity") >= 0) {
             if (artifactName.indexOf("/") > 0) {
                 //example `${targetworkspace}/sourceworkspace-WorkspaceDefaultStorage`;
                 let nametoreplace = artifactName.substr(artifactName.lastIndexOf("/") + 1);


### PR DESCRIPTION
When creating a new Synapse Workspace, a default credential representing the managed identity is created (WorkspaceManagedIdentiy).

This pull request adds the immutable, managed identity credential to the list of default artifacts so it is filtered out during subsequent deployments.