### PR TITLE
Treat AutoResolveIntegrationRuntime as a default artifact

### DIFF
--- a/build_and_deploy/test/common_utils_tests.ts
+++ b/build_and_deploy/test/common_utils_tests.ts
@@ -1,12 +1,15 @@
 import chai = require('chai');
 import {isDefaultArtifact, isStrNullOrEmpty} from "../utils/common_utils";
 import {
-    DEFAULTARTIFACT4,
-    DEFAULTARTIFACTCREDENTAILS,
-    DEFAULTARTIFACTFAIl1,
-    DEFAULTARTIFACTFAIl2, DEFAULTARTIFACTFAIl3,
-    DEFAULTARTIFACTSQL,
-    DEFAULTARTIFACTSTORAGE
+    CUSTOM_ARTIFACT_CREDENTIALS,
+    CUSTOM_ARTIFACT_INTEGRATION_RUNTIMES,
+    CUSTOM_ARTIFACT_SQL,
+    CUSTOM_ARTIFACT_STORAGE,
+    DEFAULT_ARTIFACT_CREDENTAILS,
+    DEFAULT_ARTIFACT_INTEGRATION_RUNTIMES,
+    DEFAULT_ARTIFACT_SQL,
+    DEFAULT_ARTIFACT_STORAGE,
+    MALFORED_ARTIFACT_STORAGE,
 } from "./helpers/test_fixtures";
 
 var chaiAsPromised = require("chai-as-promised");
@@ -25,30 +28,38 @@ describe('CommonUtils', function () {
     });
 
     it('Should consider it as default artifact - SQL', function (){
-        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTSQL)));
+        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULT_ARTIFACT_SQL)));
     });
 
     it('Should consider it as default artifact - Storage', function (){
-        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTSTORAGE)));
+        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULT_ARTIFACT_STORAGE)));
     });
 
     it('Should consider it as default artifact - Credentials', function (){
-        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTCREDENTAILS)));
+        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULT_ARTIFACT_CREDENTAILS)));
+    });
+
+    it('Should consider it as default artifact - Integration Runtimes', function (){
+        chai.assert.isTrue(isDefaultArtifact(JSON.stringify(DEFAULT_ARTIFACT_INTEGRATION_RUNTIMES)));
     });
 
     it('Should not consider it as default artifact - Storage', function (){
-        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTFAIl1)));
+        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(CUSTOM_ARTIFACT_STORAGE)));
     });
 
     it('Should not consider it as default artifact - Storage', function (){
-        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTFAIl2)));
+        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(MALFORED_ARTIFACT_STORAGE)));
     });
 
     it('Should not consider it as default artifact - SQL', function (){
-        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACTFAIl3)));
+        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(CUSTOM_ARTIFACT_SQL)));
     });
 
     it('Should not consider it as default artifact - Credentials', function (){
-        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(DEFAULTARTIFACT4)));
+        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(CUSTOM_ARTIFACT_CREDENTIALS)));
+    });
+
+    it('Should not consider it as default artifact - Integration Runtimes', function (){
+        chai.assert.isFalse(isDefaultArtifact(JSON.stringify(CUSTOM_ARTIFACT_INTEGRATION_RUNTIMES)));
     });
 });

--- a/build_and_deploy/test/helpers/test_fixtures.ts
+++ b/build_and_deploy/test/helpers/test_fixtures.ts
@@ -37,7 +37,7 @@ export const PIPELINEPAYLOAD = {
     ]
 }
 
-export const DEFAULTARTIFACTSQL = {
+export const DEFAULT_ARTIFACT_SQL = {
     "name": "[concat(parameters('workspaceName'), '/test-WorkspaceDefaultSqlServer')]",
     "type": "Microsoft.Synapse/workspaces/linkedServices",
     "apiVersion": "2019-06-01-preview",
@@ -62,7 +62,7 @@ export const DEFAULTARTIFACTSQL = {
     ]
 }
 
-export const DEFAULTARTIFACTSTORAGE = {
+export const DEFAULT_ARTIFACT_STORAGE = {
     "name": "[concat(parameters('workspaceName'), '/test-WorkspaceDefaultStorage')]",
     "type": "Microsoft.Synapse/workspaces/linkedServices",
     "apiVersion": "2019-06-01-preview",
@@ -82,7 +82,7 @@ export const DEFAULTARTIFACTSTORAGE = {
     ]
 }
 
-export const DEFAULTARTIFACTCREDENTAILS = {
+export const DEFAULT_ARTIFACT_CREDENTAILS = {
     "name": "[concat(parameters('workspaceName'), '/WorkspaceSystemIdentity')]",
     "type": "Microsoft.Synapse/workspaces/credentials",
     "apiVersion": "2019-06-01-preview",
@@ -93,7 +93,27 @@ export const DEFAULTARTIFACTCREDENTAILS = {
     "dependsOn": []
 }
 
-export const DEFAULTARTIFACTFAIl1 = {
+export const DEFAULT_ARTIFACT_INTEGRATION_RUNTIMES = {
+    "name": "[concat(parameters('workspaceName'), '/AutoResolveIntegrationRuntime')]",
+    "type": "Microsoft.Synapse/workspaces/integrationRuntimes",
+    "apiVersion": "2019-06-01-preview",
+    "properties": {
+        "type": "Managed",
+        "typeProperties": {
+            "computeProperties": {
+                "location": "AutoResolve",
+                "dataFlowProperties": {
+                    "computeType": "General",
+                    "coreCount": 8,
+                    "timeToLive": 0
+                }
+            }
+        }
+    },
+    "dependsOn": []
+}
+
+export const CUSTOM_ARTIFACT_STORAGE = {
     "name": "[concat(parameters('workspaceName'), '/test-WorkspaceStorage')]",
     "type": "Microsoft.Synapse/workspaces/linkedServices",
     "apiVersion": "2019-06-01-preview",
@@ -113,7 +133,7 @@ export const DEFAULTARTIFACTFAIl1 = {
     ]
 }
 
-export const DEFAULTARTIFACTFAIl2 = {
+export const MALFORED_ARTIFACT_STORAGE = {
     "name": "[concat(parameters('workspaceName'), '/test-WorkspaceDefaultStorage')]",
     "type": "Microsoft.Synapse/workspaces/linked",
     "apiVersion": "2019-06-01-preview",
@@ -133,7 +153,7 @@ export const DEFAULTARTIFACTFAIl2 = {
     ]
 }
 
-export const DEFAULTARTIFACTFAIl3 = {
+export const CUSTOM_ARTIFACT_SQL = {
     "name": "[concat(parameters('workspaceName'), '/test-WorkspaceDefaultStorage')]",
     "type": "Microsoft.Synapse/workspaces/linkedServices",
     "apiVersion": "2019-06-01-preview",
@@ -153,7 +173,7 @@ export const DEFAULTARTIFACTFAIl3 = {
     ]
 }
 
-export const DEFAULTARTIFACT4 = {
+export const CUSTOM_ARTIFACT_CREDENTIALS = {
     "name": "[concat(parameters('workspaceName'), '/Credential2')]",
     "type": "Microsoft.Synapse/workspaces/credentials",
     "apiVersion": "2019-06-01-preview",
@@ -168,5 +188,16 @@ export const DEFAULTARTIFACT4 = {
     "dependsOn": [
         "[concat(variables('workspaceId'), '/linkedServices/AzureKeyVault1')]"
     ]
+}
+
+export const CUSTOM_ARTIFACT_INTEGRATION_RUNTIMES = {
+    "name": "[concat(parameters('workspaceName'), '/IntegrationRuntime1')]",
+    "type": "Microsoft.Synapse/workspaces/integrationRuntimes",
+    "apiVersion": "2019-06-01-preview",
+    "properties": {
+        "type": "SelfHosted",
+        "typeProperties": {}
+    },
+    "dependsOn": []
 }
 

--- a/build_and_deploy/utils/artifacts_enum.ts
+++ b/build_and_deploy/utils/artifacts_enum.ts
@@ -36,11 +36,13 @@ export enum DataFactoryType {
 export enum DEFAULT_ARTIFACTS {
     sqlserver = "workspacedefaultsqlserver",
     storage = "workspacedefaultstorage",
-    credentials = "workspacesystemidentity"
+    credentials = "workspacesystemidentity",
+    integrationruntime = "autoresolveintegrationruntime"
 }
 
 export enum DEFAULT_ARTIFACTS_TYPE {
     sqlserver = "AzureSqlDW",
     storage = "AzureBlobFS",
-    credentials = "ManagedIdentity"
+    credentials = "ManagedIdentity",
+    integrationruntime = "Managed"
 }

--- a/build_and_deploy/utils/artifacts_enum.ts
+++ b/build_and_deploy/utils/artifacts_enum.ts
@@ -33,16 +33,3 @@ export enum DataFactoryType {
     managedPrivateEndpoints = "Microsoft.Synapse/workspaces/managedVirtualNetworks/managedPrivateEndpoints",
     kqlScript = "Microsoft.Synapse/workspaces/kqlscripts"
 }
-export enum DEFAULT_ARTIFACTS {
-    sqlserver = "workspacedefaultsqlserver",
-    storage = "workspacedefaultstorage",
-    credentials = "workspacesystemidentity",
-    integrationruntime = "autoresolveintegrationruntime"
-}
-
-export enum DEFAULT_ARTIFACTS_TYPE {
-    sqlserver = "AzureSqlDW",
-    storage = "AzureBlobFS",
-    credentials = "ManagedIdentity",
-    integrationruntime = "Managed"
-}

--- a/build_and_deploy/utils/common_utils.ts
+++ b/build_and_deploy/utils/common_utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {DataFactoryType, DEFAULT_ARTIFACTS, DEFAULT_ARTIFACTS_TYPE} from "./artifacts_enum";
+import {DefaultArtifact} from "./default_artifacts";
 
 export function isStrNullOrEmpty(val: string): boolean {
     if (val === undefined || val === null || val.trim() === '') {
@@ -12,12 +12,5 @@ export function isStrNullOrEmpty(val: string): boolean {
 
 export function isDefaultArtifact(artifact: string): boolean{
     let artifactJson = JSON.parse(artifact);
-    for(let key in DEFAULT_ARTIFACTS){
-        if(artifactJson.name.toLowerCase().indexOf(DEFAULT_ARTIFACTS[key as keyof typeof DEFAULT_ARTIFACTS]) != -1 &&
-            [DataFactoryType.linkedservice.toLowerCase(), DataFactoryType.credential.toLowerCase()].indexOf(artifactJson.type.toLowerCase()) != -1 &&
-            artifactJson.properties.type.toLowerCase() === DEFAULT_ARTIFACTS_TYPE[key as keyof typeof DEFAULT_ARTIFACTS_TYPE].toLowerCase()
-        )
-            return true;
-    };
-    return false;
+    return DefaultArtifact.LIST.some((e: DefaultArtifact) => e.matches(artifactJson.name, artifactJson.properties.type, artifactJson.type));
 }

--- a/build_and_deploy/utils/default_artifacts.ts
+++ b/build_and_deploy/utils/default_artifacts.ts
@@ -1,0 +1,20 @@
+
+import {DataFactoryType} from "./artifacts_enum";
+
+export class DefaultArtifact {
+    public static LIST: DefaultArtifact[] = [
+      new DefaultArtifact("workspacedefaultsqlserver", "azuresqldw", DataFactoryType.linkedservice),
+      new DefaultArtifact("workspacedefaultstorage", "azureblobfs", DataFactoryType.linkedservice),
+      new DefaultArtifact("workspacesystemidentity", "managedidentity", DataFactoryType.credential),
+      new DefaultArtifact("autoresolveintegrationruntime", "managed", DataFactoryType.integrationruntime),
+    ];
+
+    private constructor(private name: string, private type: string, private dataFactoryType: DataFactoryType) {
+    }
+
+    public matches(name: string, type: string, dataFactoryType: string): boolean {
+      return name.toLowerCase().indexOf(this.name) >= 0
+        && type.toLowerCase() === this.type
+        && dataFactoryType === this.dataFactoryType;
+    }
+}


### PR DESCRIPTION
When creating a new Synapse Workspace, an Integration Runtime named `AutoResolveIntegrationRuntime` is automatically created.

> The workspace manages the integration runtime in Azure to connect to required data source/destination or external compute in public network. The compute resource is elastic allocated based on performance requirement of activities.
