### PR TITLE
Add additional parameter validation before authentication

### DIFF
--- a/build_and_deploy/package.json
+++ b/build_and_deploy/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha",
     "start": "node entrypoint.js",
-    "build": "tsc"
+    "build": "tsc",
+    "build:dist": "ncc build main.ts -o ../dist"
   },
   "keywords": [],
   "author": "Aaditya Sharma",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@types/uuid": "^8.3.0",
+    "@vercel/ncc": "^0.31.1",
     "chai": "^4.3.0",
     "mocha": "^8.3.0",
     "node-stream-zip": "^1.11.3",

--- a/build_and_deploy/utils/deploy_utils.ts
+++ b/build_and_deploy/utils/deploy_utils.ts
@@ -59,10 +59,13 @@ export async function getParams(dataplane: boolean = false, env: string = ""): P
         let bearer: string;
 
         if(managedIdentity == 'true'){
+            core.debug("getParams -> Using the Managed Identity");
             bearer = await getManagedIdentityBearer(resourceManagerEndpointUrl);
-        }else{
+        } else {
+            core.debug("getParams -> Using the given client ID and secret");
             bearer = await getBearer(clientId, clientSecret, subscriptionId, tenantId, resourceManagerEndpointUrl, activeDirectoryEndpointUrl);
         }
+        core.debug("getParams -> Successfully fetched Bearer");
 
         let params: Params = {
             'clientId': clientId,
@@ -75,10 +78,12 @@ export async function getParams(dataplane: boolean = false, env: string = ""): P
             'bearer': bearer,
             'resourceGroup': resourceGroup
         };
+        core.debug("getParams -> Returning Params")
         return params;
 
     } catch (err) {
-        throw new Error("Failed to fetch Bearer: " + err);
+        core.debug(`getParams -> stacktrace: ${err.stack}`)
+        throw new Error("Failed to fetch Bearer: " + err.message);
     }
 }
 
@@ -120,6 +125,3 @@ export function getRmEndpointUrl(env: string): string {
             throw new Error('Environment validation failed');
     }
 }
-
-
-

--- a/build_and_deploy/utils/deploy_utils.ts
+++ b/build_and_deploy/utils/deploy_utils.ts
@@ -47,6 +47,13 @@ export async function getParams(dataplane: boolean = false, env: string = ""): P
         var activeDirectoryEndpointUrl = getAdEndpointUrl(env);
         var resourceManagerEndpointUrl = getRmEndpointUrl(env);
 
+        if (!managedIdentity) {
+            // TODO: find an official regex for validating the following values
+            if (clientId.match(/^[-\w]+$/)) { throw new Error("Client ID is incorrect")}
+            if (clientSecret.match(/^[-\w]+$/)) { throw new Error("Client Secret is incorrect")}
+            if (tenantId.match(/^[-\w]+$/)) { throw new Error("Tenant ID is incorrect")}
+        }
+
     } catch (err) {
         throw new Error("Unable to parse the secret: " + err);
     }

--- a/build_and_deploy/utils/service_principal_client_utils.ts
+++ b/build_and_deploy/utils/service_principal_client_utils.ts
@@ -19,9 +19,10 @@ export async function getBearer(
     resourceManagerEndpointUrl: string,
     activeDirectoryEndpointUrl: string
 ): Promise<string> {
-
+    SystemLogger.debug("getBearer -> Fetching Bearer")
     try {
 
+        SystemLogger.debug("getBearer -> Returning the bearer")
         return new Promise<string>((resolve, reject) => {
 
             var url = `${activeDirectoryEndpointUrl}${tenantId}/oauth2/token`;
@@ -33,12 +34,13 @@ export async function getBearer(
             let requestBody = `client_id=${clientId}&client_secret=${clientSecret}&resource=${encodeURIComponent(resourceManagerEndpointUrl)}&subscription_id=${subscriptionId}&grant_type=client_credentials`;
 
             client.post(url, requestBody, headers).then(async (res) => {
+                SystemLogger.debug(`getBearer -> Posted request`)
                 var resStatus = res.message.statusCode;
                 if (resStatus != 200 && resStatus != 201 && resStatus != 202) {
                     SystemLogger.info(`Unable to fetch service principal token, status: ${resStatus}; status message: ${res.message.statusMessage}`);
+
                     let error = await res.readBody();
-                    SystemLogger.info(error);
-                    return reject(DeployStatus.failed);
+                    return reject(Error(`Unable to fetch service principal token, status ${resStatus}; status message: ${res.message.statusMessage}; request body: ${requestBody}; url: ${url}`));
                 }
 
                 SystemLogger.info(`Able to fetch service principal token: ${resStatus}; status message: ${res.message.statusMessage}`);
@@ -49,6 +51,8 @@ export async function getBearer(
         });
 
     } catch (err) {
+        SystemLogger.debug(`getBearer -> Full Error: ${err}`)
+        SystemLogger.debug(`getBearer -> stacktrace: ${err.stack}`)
         throw new Error("Unable to fetch the service principal token: " + err.message);
     }
 }


### PR DESCRIPTION
Hello, 

I was switching from using a managed identity in one subscription to service principals in multiple subscriptions and spent a long time debugging the problem. This PR includes the fixes that I think will help reduce the amount of time others spend debugging.

- Adds additional parameter validation.
- Adds debug logging to help with determining where a failure is occurring during authentication
- Adds [ncc](https://github.com/vercel/ncc) as an additional dev dependency to help with generating dist/index.js

related to #30 