### PR TITLE
clearer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ uses: Azure/synapse-workspace-deployment
 - uses: Azure/synapse-workspace-deployment
         with:
           TargetWorkspaceName: 'targetworkspace'
-          ArtifactsFolder: './RootFolder'
+          ArtifactsFolder: '$GITHUB_WORKSPACE'
           operation: 'validate'
 - uses: actions/upload-artifact@v3
         with:
@@ -99,7 +99,7 @@ uses: Azure/synapse-workspace-deployment
 uses: Azure/synapse-workspace-deployment
         with:
           TargetWorkspaceName: 'targetworkspace'
-          ArtifactsFolder: './RootFolder'
+          ArtifactsFolder: '$GITHUB_WORKSPACE'
           environment: 'Azure Public'
           resourceGroup: 'myresourcegroup'
           clientId: ${{ secrets.CLIENTID }}


### PR DESCRIPTION
For the validate and the validate and deploy operation, these need to be performed on wherever you checkout the branch to. 

So changed the guidance in the README to '$GITHUB_WORKSPACE' for the ArtifactsFolder. 

We may also want to link to https://techcommunity.microsoft.com/t5/azure-synapse-analytics-blog/automating-the-publishing-of-workspace-artifacts-in-synapse-cicd/ba-p/3603042 which has additional info on the validate and validate and deploy operations (even though here it is for Azure DevOps). 

We may also want to update the sample code with a checkout action right before the validate and the validate and deploy for extra clarity. 