### PR TITLE
Update deprecated GitHub Action: checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: 'Checking out repo code'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: 'Validate build'
       working-directory: ./build_and_deploy


### PR DESCRIPTION
Node.js 12 actions are deprecated. The checkout actions now needs to use Node.js 16 starting in v3.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.