### PR TITLE
chore: enable proxy

### DIFF
--- a/build_and_deploy/Operations/BundleManager.ts
+++ b/build_and_deploy/Operations/BundleManager.ts
@@ -6,6 +6,7 @@ import * as https from 'https';
 import * as path from 'path';
 import {spawn} from "child_process";
 import {SystemLogger} from "../utils/logger";
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 export class BundleManager {
     private static readonly prodBundleUrl = 'https://web.azuresynapse.net/assets/cmd-api/main.js';
@@ -35,7 +36,9 @@ export class BundleManager {
             const file = fs.createWriteStream(BundleManager.defaultBundleFilePath);
             return new Promise((resolve, reject) => {
                 SystemLogger.info("Downloading asset file");
-                https.get(this._bundleUrl, (response) => {
+                const proxy = process.env.HTTPS_PROXY;
+                const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+                https.get(this._bundleUrl, { agent }, (response) => {
                     response.pipe(file);
                     file.on('finish', () => {
                         file.close();

--- a/build_and_deploy/package.json
+++ b/build_and_deploy/package.json
@@ -34,7 +34,8 @@
     "ts-mockito": "^2.6.1",
     "tsconfig-paths": "^3.9.0",
     "typed-rest-client": "^1.7.3",
-    "uuid": "8.3.0"
+    "uuid": "8.3.0",
+    "https-proxy-agent": "^5.0.0"
   },
   "devDependencies": {
     "@types/uuid": "^8.3.0",


### PR DESCRIPTION
Enables users that are behind a corporate proxy to be able to download the asset file.